### PR TITLE
Set the account to use the actual chessboard choice value again

### DIFF
--- a/app/src/main/java/com/example/jarchess/jaraccount/JarAccount.java
+++ b/app/src/main/java/com/example/jarchess/jaraccount/JarAccount.java
@@ -103,8 +103,7 @@ public class JarAccount {
     }
 
     public synchronized ChessboardStyle getBoardStyle() {
-//        return ChessboardStyles.getFromInt(chessboardStyleInt.getValue()).getChessboardStyle();
-        return ChessboardStyleChoice.WOOD_2.getChessboardStyle();
+        return ChessboardStyleChoice.getFromInt(chessboardStyleInt.getValue()).getChessboardStyle();
     }
 
     public JSONObject getJsonForLogout(JSONObject signoutJson) {


### PR DESCRIPTION
#22 had hardcoded the chessboard style to return in JarAccount (for testing), this makes it use the stored value again.